### PR TITLE
A couple of small changes from Debian cdimage project

### DIFF
--- a/yoga_fw_extract/yoga_fw_extract.sh
+++ b/yoga_fw_extract/yoga_fw_extract.sh
@@ -107,7 +107,7 @@ WIN_PART=""									# Windows partition path
 echo -e "${TXT_UNDERLINE}Getting Windows drivers...${TXT_NORMAL}"
 echo "Searching for Windows partition..."
 WIN_PART_LABEL="Windows"
-WIN_PART_TMP=`blkid -L "${WIN_PART_LABEL}"`
+WIN_PART_TMP=`/sbin/blkid -L "${WIN_PART_LABEL}"`
 if [ $? -eq 0 ]; then
 	echo "	Found Windows partition: ${WIN_PART_TMP}"
 	WIN_PART=${WIN_PART_TMP}

--- a/yoga_fw_extract/yoga_fw_extract.sh
+++ b/yoga_fw_extract/yoga_fw_extract.sh
@@ -432,6 +432,9 @@ if [ ${COPY_ERR} -eq 0 ]; then
 	if [ -e "${PATH_LIBFW_ATH10K}/WCN3990" ]; then
 		backup_or_delete "Atheros" "${PATH_LIBFW_ATH10K}/WCN3990" "${BKUP_DATETIME}"
 	fi
+	if [ ! -e "${PATH_LIBFW_ATH10K}" ]; then
+		sudo mkdir -p "${PATH_LIBFW_ATH10K}" &> /dev/null
+	fi
 	echo -n "Copying new Atheros ath10k firmware: "
 	sudo cp -r "${PATH_FW_ATH10K}" "${PATH_LIBFW_ATH10K}" &> /dev/null
 	done_failedexit $?


### PR DESCRIPTION
yoga_fw_extract.sh is very useful for aarch64-laptops [debian-cdimage](https://github.com/aarch64-laptops/debian-cdimage) project to extract firmware files from Windows partition. We really appreciate the effort. This is a couple of small changes we made when using the script, and we would try to propose them for upstream inclusion.  Thanks!